### PR TITLE
- Fixed Oracle driver to map timestamps with ranges to simple timesta…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='slippinj',
-    version='1.6.1',
+    version='1.6.2',
     author='Data Architects SCM Spain',
     author_email='data.architecture@scmspain.com',
     packages=find_packages('src'),


### PR DESCRIPTION
…mps because Hive doesn't accept timestamps with ranges.

- Fixed Oracle driver in order to detect when a number is a double or an integer.