### PR TITLE
hotfix/3.0.1 Fixed Tlacuilo for single file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='slippinj',
-    version='3.0.0',
+    version='3.0.1',
     author='Data Architects SCM Spain',
     author_email='data.architecture@scmspain.com',
     packages=find_packages('src'),

--- a/src/slippinj/cli/scripts/tlacuilo.py
+++ b/src/slippinj/cli/scripts/tlacuilo.py
@@ -36,11 +36,6 @@ class Tlacuilo(BasicScript):
                 'action': 'append'
             },
             {
-                'short': '-f',
-                'long': '--configuration-file',
-                'help': 'File where all the configuration is stored'
-            },
-            {
                 'short': '-i',
                 'long': '--cluster-information',
                 'action': 'store_true',

--- a/tests/slippinj/cli/scripts/test_tlacuilo.py
+++ b/tests/slippinj/cli/scripts/test_tlacuilo.py
@@ -15,7 +15,7 @@ class TestTlacuilo:
 
         Tlacuilo(mocked_args_parser).configure()
 
-        assert 7 == mocked_args_parser.add_argument.call_count
+        assert 6 == mocked_args_parser.add_argument.call_count
 
     def test_script_raise_an_error_when_path_is_not_absolute(self):
         mocked_args = Mock()


### PR DESCRIPTION
-Now Tlacuilo runs correctly when a single .yml file is given with the -w parameter, instead of asking interactively for files always