### PR TITLE
GDPR templates: oozie jobs will be executed in order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ openpyxl==2.3.3
 paramiko==1.16.0
 pymssql==2.1.3
 psycopg2==2.7.3.1
-pyyaml==3.11
+oyaml==0.1
 pymysql==0.7.11
 cx_Oracle==6.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='slippinj',
-    version='3.0.1',
+    version='3.1.0',
     author='Data Architects SCM Spain',
     author_email='data.architecture@scmspain.com',
     packages=find_packages('src'),


### PR DESCRIPTION
Defined jobs in slippin-jimmy's templates will be executed in the order declared by the template.

oyaml preserves dict ordering unlike pyyaml